### PR TITLE
Fixed size units in tm/clone

### DIFF
--- a/tm/clone
+++ b/tm/clone
@@ -75,7 +75,7 @@ CLONE_CMD=$(cat <<EOF
     set -e
 
     # get size
-    SIZE=\$($SUDO $LVS --noheadings -o lv_size "$SOURCE_DEV")
+    SIZE=\$($SUDO $LVS --noheadings -o lv_size --units B "$SOURCE_DEV")
 
     # create lv
     $SUDO $LVCREATE -L\${SIZE} ${VG_NAME} -n ${TARGET_LV_NAME}


### PR DESCRIPTION
There is a bug in tm/clone. It requests size from 'lvs', but it uses human readable units. Then this size is applied to lvcreate, but LVM rounds it. I fixed it by specifying Byte units.

You can try it with size 10000M. Creating and copying image is ok, because OpenNebula uses size from database which is exactly 10000M. But when cloning (instantiate non-persistent volume) it reads SIZE from LVM and creates a bit bigger new volume (+8M). Till this it is still ok. But when copying this new image (deferred snapshot, etc...) then size from database is used and "dd" fails with "No space left on device".