### PR TITLE
Fixed mkfs of raw devices

### DIFF
--- a/datastore/mkfs
+++ b/datastore/mkfs
@@ -87,7 +87,7 @@ REGISTER_CMD=$(cat <<EOF
     $SUDO $(tgt_setup_lun "$IQN" "$DEV")
     $SUDO $(tgt_admin_dump_config "$TARGET_CONF")
 
-    if [ "$FSTYPE" != "save_as" ]; then
+    if [ "$FSTYPE" != "save_as" -a "$FSTYPE" != "raw" ]; then
         $SUDO $(mkfs_command "$DEV" "$FSTYPE")
     fi
 EOF


### PR DESCRIPTION
Raw images does not work for iscsi addon. Common function mkfs_command returns empty command for raw, but it is used with sudo command and results in error. So I just added condition to not run command for fstype "raw" in iscsi addon.