### PR TITLE
RAW device creation does not work

### DIFF
--- a/datastore/mkfs
+++ b/datastore/mkfs
@@ -80,6 +80,12 @@ LV_NAME="lv-one-${ID}"
 IQN="$BASE_IQN:$DST_HOST.$VG_NAME.$LV_NAME"
 DEV="/dev/$VG_NAME/$LV_NAME"
 
+if [ "$FSTYPE" != "save_as" ]; then
+    MKFS_CMD=$(mkfs_command "$DEV" "$FSTYPE")
+else
+    MKFS_CMD=
+fi
+
 REGISTER_CMD=$(cat <<EOF
     set -e
     $SUDO $LVCREATE -L${SIZE}M ${VG_NAME} -n ${LV_NAME}
@@ -87,8 +93,8 @@ REGISTER_CMD=$(cat <<EOF
     $SUDO $(tgt_setup_lun "$IQN" "$DEV")
     $SUDO $(tgt_admin_dump_config "$TARGET_CONF")
 
-    if [ "$FSTYPE" != "save_as" ]; then
-        $SUDO $(mkfs_command "$DEV" "$FSTYPE")
+    if [ -n "$MKFS_CMD" ]; then
+        $SUDO $MKFS_CMD
     fi
 EOF
 )


### PR DESCRIPTION
When creating datablock image you can use "raw" in "FS type" field to not format new image. OpenNebula support function mkfs_command returns empty command in this case. But in addon-iscsi the returned command is used with sudo resulting in sudo error.

I fixed this bug by testing empty command and not running sudo in this case.