### PR TITLE
Copying image between two volume groups fails

### DIFF
--- a/datastore/clone
+++ b/datastore/clone
@@ -78,8 +78,9 @@ LV_NAME="lv-one-${ID}"
 IQN="$BASE_IQN:$DST_HOST.$VG_NAME.$LV_NAME"
 DEV="/dev/$VG_NAME/$LV_NAME"
 
+VG_SRC=$(echo $SRC|awk -F. '{print $(NF-1)}')
 LV_SRC=$(echo $SRC|awk -F. '{print $NF}')
-DEV_SRC="/dev/$VG_NAME/$LV_SRC"
+DEV_SRC="/dev/$VG_SRC/$LV_SRC"
 
 CLONE_CMD=$(cat <<EOF
     set -e


### PR DESCRIPTION
If I use 2 different volume groups on the same storage (one for disks and one for ssd), it fails copying images between them. It is because source "volume group" is determined from target image instead of source image. Fixed this.