### PR TITLE
Compatibility with OpenNebula 4.14

### DIFF
--- a/tm/cpds
+++ b/tm/cpds
@@ -16,19 +16,20 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
-# mvds host:remote_system_ds/disk.i fe:SOURCE
+# cpds host:remote_system_ds/disk.i fe:SOURCE snapid vmid dsid
 #   - fe is the front-end hostname
 #   - SOURCE is the path of the disk image in the form DS_BASE_PATH/disk
 #   - host is the target host to deploy the VM
 #   - remote_system_ds is the path for the system datastore in the host
 #   - vmid is the id of the VM
 #   - dsid is the target datastore (0 is the system datastore)
+#   - snapid is the snapshot id. "-1" for none
 
 SRC=$1
 DST=$2
-
-VMID=$3
-DSID=$4
+SNAP_ID=$3
+VMID=$4
+DSID=$5
 
 if [ -z "${ONE_LOCATION}" ]; then
     TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
@@ -39,6 +40,12 @@ fi
 DRIVER_PATH=$(dirname $0)
 
 . $TMCOMMON
+
+if [ "$SNAP_ID" != "-1" ]
+then
+    error_message "cpds: Save image from snapshot not supported for iscsi"
+    exit 1
+fi
 
 source ${DRIVER_PATH}/../../datastore/iscsi/iscsi.conf
 


### PR DESCRIPTION
OpenNebula 4.14 introduces new style of snapshots and also changes parameters for one existing script - tm/cpds. It prevents "Save as" of disks. 

This patch only fixes this problem, so this iscsi addon can be used with 4.14 version. I will make full snapshots patch later.

