### PR TITLE
Saveas 4.14

### DIFF
--- a/tm/mvds
+++ b/tm/mvds
@@ -16,13 +16,13 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
-# mvds host:remote_system_ds/disk.i fe:SOURCE
+# mvds host:remote_system_ds/disk.i fe:SOURCE vm_id ds_id
 #   - fe is the front-end hostname
 #   - SOURCE is the path of the disk image in the form DS_BASE_PATH/disk
 #   - host is the target host to deploy the VM
 #   - remote_system_ds is the path for the system datastore in the host
-#   - vmid is the id of the VM
-#   - dsid is the target datastore (0 is the system datastore)
+#   - vm_id is the id of the VM
+#   - ds_id is the target datastore (0 is the system datastore)
 
 SRC=$1
 DST=$2
@@ -43,7 +43,6 @@ DRIVER_PATH=$(dirname $0)
 source ${DRIVER_PATH}/../../datastore/iscsi/iscsi.conf
 
 SRC_HOST=`arg_host $SRC`
-NEW_IQN="$DST"
 
 DISK_ID=$(echo $SRC|awk -F. '{print $NF}')
 
@@ -58,17 +57,9 @@ unset i j XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <(onevm show -x $VMID| $XPATH \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SAVE_AS \
-                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/PERSISTENT)
+                    /VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/SOURCE)
 
 IQN="${XPATH_ELEMENTS[j++]}"
-SAVE_AS="${XPATH_ELEMENTS[j++]}"
-PERSISTENT="${XPATH_ELEMENTS[j++]}"
-
-if [ -z "$PERSISTENT" ]; then
-    IQN=$IQN-$VMID
-fi
 
 log "Logging out $IQN"
 
@@ -80,40 +71,3 @@ EOF
 
 ssh_exec_and_log "$SRC_HOST" "$LOGOUT_CMD" \
     "Error logging out $IQN"
-
-# Exit if not save_as. We are finished if this was a persistent image.
-[ -z "$SAVE_AS" ] && exit 0
-
-#-------------------------------------------------------------------------------
-# IQN and TARGETs
-#-------------------------------------------------------------------------------
-
-LV_NAME=`echo $IQN|$AWK -F. '{print $(NF)}'`
-VG_NAME=`echo $IQN|$AWK -F. '{print $(NF-1)}'`
-SOURCE_DEV="/dev/$VG_NAME/$LV_NAME"
-
-TARGET=`arg_path $IQN`
-TARGET_LV_NAME=`echo $NEW_IQN|$AWK -F. '{print $(NF)}'`
-TARGET_DEV="/dev/$VG_NAME/$TARGET_LV_NAME"
-TARGET_HOST="${TARGET%.$VG_NAME.$LV_NAME}"
-
-CLONE_CMD=$(cat <<EOF
-    set -e
-
-    # clone lv with dd
-    $SUDO $DD if=$SOURCE_DEV of=$TARGET_DEV bs=2M
-
-    # remove if source_dev is not persistent
-    if [ -z "$PERSISTENT" ]; then
-        TID=\$($SUDO $(tgtadm_get_tid_for_iqn "$IQN"))
-
-        $SUDO $(tgtadm_target_delete "\$TID")
-        $SUDO $SYNC
-        $SUDO $LVREMOVE -f $VG_NAME/$LV_NAME
-        $SUDO $(tgt_admin_dump_config "$TARGET_CONF")
-    fi
-EOF
-)
-
-ssh_exec_and_log "$TARGET_HOST" "$CLONE_CMD" \
-        "Error cloning $DST_HOST:$TARGET_DEV or removing nonpersistent $IQN"


### PR DESCRIPTION
The mvds now only manages saving persistent images back to the system datastore. For shared system datastores it will be a simple exit 0. In previous OpenNebula versions this script also served the purpose saving disk marked withed SAVEAS at the end of the VM lifecycle (what used to be called a deferred disk-snapshot). Since this action is no longer possible (has been replaced with onevm disk-saveas – see above) the mvds action has been largely simplified.

For iSCSI only logouts iSCSI volume.